### PR TITLE
Add SCM for org.graalvm.sdk

### DIFF
--- a/recipes/org/graalvm/sdk/scm.yaml
+++ b/recipes/org/graalvm/sdk/scm.yaml
@@ -1,0 +1,7 @@
+---
+type: "git"
+uri: "https://github.com/oracle/graal.git"
+path: "truffle"
+tagMapping:
+  - pattern: 21.3.2
+    tag: vm-21.3.2


### PR DESCRIPTION
Note that this won't work because it requires its own custom build system written in Python. The build state seems to get stuck in `ArtifactBuildBuilding`, but it's probably an improvement over having no information at all.
